### PR TITLE
Add 'Synth1' Audio Unit and VST plugins

### DIFF
--- a/Casks/synth1-au.rb
+++ b/Casks/synth1-au.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'synth1-au' do
+  version '1.13beta8'
+  sha256 '78660848d78c19cdda2597bd050a2ec95fa915cc1a1ab598bde0192a1cbc9a6f'
+
+  url 'http://www.geocities.jp/daichi1969/softsynth/Synth1macau113beta8.zip'
+  name 'Synth1 (AU)'
+  name 'Synth 1 (AU)'
+  homepage 'http://www.geocities.jp/daichi1969/softsynth/'
+  license :gratis
+
+  audio_unit_plugin 'Synth1.component'
+end

--- a/Casks/synth1-vst.rb
+++ b/Casks/synth1-vst.rb
@@ -1,0 +1,12 @@
+cask :v1 => 'synth1-vst' do
+  version '1.13beta8'
+  sha256 '6b172b9433358bce21f0af75a28505c3365d934fadee04a738336e7f5f601675'
+
+  url 'http://www.geocities.jp/daichi1969/softsynth/Synth1macvst113beta8.zip'
+  name 'Synth1 (VST)'
+  name 'Synth 1 (VST)'
+  homepage 'http://www.geocities.jp/daichi1969/softsynth/'
+  license :gratis
+
+  vst_plugin 'Synth1.vst'
+end


### PR DESCRIPTION
These are two seperate casks of the same plugin. One for the Audio Unit, and one for the VST.
Neither is the main type as each DAW (Ableton Live, Cubase, Apple Logic, etc.) may use one or the other.
